### PR TITLE
Fixed compiler warnings, doing a neuroc_release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Type: Package
 Package: robex
-Version: 1.2.6
+Version: 1.2.6.1
 Title: Robust Brain Extraction ('ROBEX')
 Description: Wrapper for Robust Brain Extraction ('ROBEX') algorithm
     <DOI:10.1109/TMI.2011.2138152>.  Provides the binary distributions

--- a/configure
+++ b/configure
@@ -39,6 +39,7 @@ cd build
 #     -DCMAKE_INSTALL_PREFIX:PATH="${R_PACKAGE_DIR}/inst/"  \
 
 cmake -DITK_DIR:PATH="${ITKDIR}" \
+    -DCMAKE_CXX_FLAGS=-Wno-inconsistent-missing-override \
     -DCMAKE_EXE_LINKER_FLAGS:STRING=-lstdc++ \
     -DCMAKE_BUILD_TYPE:STRING="${CMAKE_BUILD_TYPE}" ../../ROBEX
 cd ../../

--- a/configure.win
+++ b/configure.win
@@ -55,6 +55,7 @@ cmake.exe \
     -DITK_DIR:PATH="${ITKDIR}" \
     -DCMAKE_EXE_LINKER_FLAGS:STRING=-lstdc++ \
     -DCMAKE_BUILD_TYPE:STRING="${CMAKE_BUILD_TYPE}" \
+    -DCMAKE_CXX_FLAGS=-Wno-inconsistent-missing-override \
     ../../ROBEX
 cd ../../
 


### PR DESCRIPTION
Per [this](https://stackoverflow.com/questions/32626171/xcode-7-how-to-suppress-warning-overrides-a-member-function-but-is-not-marked/32627021) thread, I've adjusted the `configure` file to ignore warnings caused by the C++ code from `ROBEX`. Ran some tests (based on neuroc yml files) and results are [here](https://travis-ci.com/github/adigherman/robex/builds/166751194).

Increased the version number slightly and tagged the commit for neuroc_release.

<details><summary>Neuroconductor internal tracking</summary>
<ul><li>Time spent: minimum</li>
<li>Severity: moderate</li>
<li>Code Changes: minimum</li>
</ul>
</details>